### PR TITLE
Add new $CAPTURE_OPTIONS config

### DIFF
--- a/conf/isitfoggy.conf.example
+++ b/conf/isitfoggy.conf.example
@@ -20,3 +20,5 @@ ORIGIN_FQDN="zero.isitfoggy.today"
 CLOUDFLARE_DNS_SERVER="zelda.ns.cloudflare.com"
 CLOUDFLARE_EMAIL="me@example.com"
 CLOUDFLARE_API_KEY="foiewqhjfoefu98323n2oiu328"
+
+CAPTURE_OPTIONS="-sh 100 -ISO 100 -co 15 ${ss_flag} -sa 7 -w 1920 -h 1080 -roi 0,0.17,0.80,1 -n -a 12 -th none -q 16 -o ${outfile}"

--- a/snap.sh
+++ b/snap.sh
@@ -49,7 +49,7 @@ function capture() {
     outfile=$1
     light=$2
     ss_flag=$(get_shutter_speed $2)
-    raspistill -sh 100 -ISO 100 -co 15 $ss_flag -sa 7 -w 1920 -h 1080 -roi 0,0.17,0.80,1 -n -a 12 -th none -q 16 -o $outfile
+    raspistill ${CAPTURE_OPTIONS}
 }
 
 function test_dir_write() {

--- a/snap.sh
+++ b/snap.sh
@@ -49,7 +49,7 @@ function capture() {
     outfile=$1
     light=$2
     ss_flag=$(get_shutter_speed $2)
-    raspistill ${CAPTURE_OPTIONS}
+    raspistill ${CAPTURE_OPTIONS--sh 100 -ISO 100 -co 15 $ss_flag -sa 7 -w 1920 -h 1080 -roi 0,0.17,0.80,1 -n -a 12 -th none -q 16 -o $outfile}
 }
 
 function test_dir_write() {


### PR DESCRIPTION
This adds support for adjusting the options passed to raspistill by specifying `CAPTURE_OPTIONS` in the config. We adjust the sample config to note this. See http://wiki.bash-hackers.org/syntax/pe#use_a_default_value for details on the syntax used in snap.sh. By specifying a default value to be used in the event that CAPTURE_OPTIONS is not set, we maintain backwards compatibility for users.

Fixes #17 