### PR TITLE
Lazy eval and safety

### DIFF
--- a/conf/isitfoggy.conf.example
+++ b/conf/isitfoggy.conf.example
@@ -21,4 +21,4 @@ CLOUDFLARE_DNS_SERVER="zelda.ns.cloudflare.com"
 CLOUDFLARE_EMAIL="me@example.com"
 CLOUDFLARE_API_KEY="foiewqhjfoefu98323n2oiu328"
 
-CAPTURE_OPTIONS="-sh 100 -ISO 100 -co 15 ${ss_flag} -sa 7 -w 1920 -h 1080 -roi 0,0.17,0.80,1 -n -a 12 -th none -q 16 -o ${outfile}"
+CAPTURE_OPTIONS='-sh 100 -ISO 100 -co 15 ${ss_flag} -sa 7 -w 1920 -h 1080 -roi 0,0.17,0.80,1 -n -a 12 -th none -q 16 -o ${outfile}'

--- a/snap.sh
+++ b/snap.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -x
+#!/bin/bash
+set -euxo pipefail
+
 CONFIG_FILE=/etc/isitfoggy.conf
 
 function check_config() {
@@ -7,11 +9,11 @@ function check_config() {
 }
 
 function is_dir_bigger_than() {
-	dir=$1
-	limit=$2
-	dir_size=$(du -s $dir/ |awk '{print $1}')
-	limit=$2
-	[[ $dir_size -gt $limit ]] && return 0 || return 1
+    dir=$1
+    limit=$2
+    dir_size=$(du -s $dir/ |awk '{print $1}')
+    limit=$2
+    [[ $dir_size -gt $limit ]] && return 0 || return 1
 }
 
 function log() {
@@ -39,45 +41,46 @@ function get_snap_interval() {
 }
 
 function purge_oldest_day_in_dir() {
-	dir=$1
-	dir_to_purge=$(find $dir -type d -regextype sed -regex ".*/[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}" |sort -rn |tail -1)
-	echo "Purging directory: $dir_to_purge"
-	[[ -z $dir_to_purge ]] || rm -rf $dir_to_purge
+    dir=$1
+    dir_to_purge=$(find $dir -type d -regextype sed -regex ".*/[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}" |sort -rn |tail -1)
+    echo "Purging directory: $dir_to_purge"
+    [[ -z $dir_to_purge ]] || rm -rf $dir_to_purge
 }
 
 function capture() {
     outfile=$1
     light=$2
     ss_flag=$(get_shutter_speed $2)
-    raspistill ${CAPTURE_OPTIONS--sh 100 -ISO 100 -co 15 $ss_flag -sa 7 -w 1920 -h 1080 -roi 0,0.17,0.80,1 -n -a 12 -th none -q 16 -o $outfile}
+    raspistill $(eval echo ${CAPTURE_OPTIONS--sh 100 -ISO 100 -co 15 $ss_flag -sa 7 -w 1920 -h 1080 -roi 0,0.17,0.80,1 -n -a 12 -th none -q 16 -o $outfile})
 }
 
 function test_dir_write() {
     if ! touch $1/write_test ; then
         echo "Cannot write in $1. Exiting"
         exit 1
+    else
+        rm -f $1/write_test
     fi
 }
 
-check_config
-source $CONFIG_FILE
-test_dir_write $PIC_DIR
-test_dir_write $TMP_DIR
-test_dir_write $LOG_DIR
-
-TMP_PIC_PATH="$TMP_DIR/snap.jpg"
-MEASURE_FILE="$TMP_DIR/measure.jpg"
-LOG_FILE="$LOG_DIR/$(basename $0).log"
-
 while true; do
+	check_config
+	source $CONFIG_FILE
+	test_dir_write $PIC_DIR
+	test_dir_write $TMP_DIR
+	test_dir_write $LOG_DIR
+
+	TMP_PIC_PATH="$TMP_DIR/snap.jpg"
+	MEASURE_FILE="$TMP_DIR/measure.jpg"
+	LOG_FILE="$LOG_DIR/$(basename $0).log"
 	cur_date=$(date +%Y-%m-%d)
 	cur_time=$(date +%H%M%S)
 	while is_dir_bigger_than "$PIC_DIR" $PIC_DIR_SIZE ; do
 		purge_oldest_day_in_dir "$PIC_DIR"
 	done
 	mkdir -p $PIC_DIR/$cur_date
-    percent_light=$(get_light)
-    snap_interval=$(get_snap_interval $percent_light)
+	percent_light=$(get_light)
+	snap_interval=$(get_snap_interval $percent_light)
 	capture "$TMP_PIC_PATH" $percent_light
 	new_file_path=$PIC_DIR/$cur_date/$cur_time.jpg
 	cp $TMP_PIC_PATH $PIC_DIR/$cur_date/$cur_time.jpg


### PR DESCRIPTION
As-is, the code is a bit unhappy that when we source the config, we can't properly evaluate CAPTURE_OPTIONS due to ss_flag not being defined. This moves us to using lazy evaluation. It also adjusts snap.sh to error out when there are issues. Finally, it makes snap.sh better at picking up config changes.